### PR TITLE
Handle key repeat as key press

### DIFF
--- a/engi_glfw.go
+++ b/engi_glfw.go
@@ -92,7 +92,7 @@ func run(title string, width, height int, fullscreen bool) {
 	})
 
 	window.SetKeyCallback(func(window *glfw.Window, k glfw.Key, s int, a glfw.Action, m glfw.ModifierKey) {
-		if a == glfw.Press {
+		if a == glfw.Press || a == glfw.Repeat {
 			responder.Key(Key(k), Modifier(m), PRESS)
 		} else {
 			responder.Key(Key(k), Modifier(m), RELEASE)


### PR DESCRIPTION
As there's no case for key repeat, this should handle it as a key press. That way the callbacks are still being called. Thoughts?
