### PR TITLE
Upgrade to azul3d.org/native/glfw.v4 package.

### DIFF
--- a/engi_glfw.go
+++ b/engi_glfw.go
@@ -16,60 +16,60 @@ import (
 	"os"
 	"runtime"
 
-	glfw "azul3d.org/native/glfw.v3.1"
+	"azul3d.org/native/glfw.v4"
 	"github.com/ajhager/webgl"
 )
 
 var window *glfw.Window
 
+// fatalErr calls log.Fatal with the given error if it is non-nil.
+func fatalErr(err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
 func run(title string, width, height int, fullscreen bool) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	if err := glfw.Init(); err != nil {
-		defer glfw.Terminate()
-	}
+	fatalErr(glfw.Init())
 
 	monitor, err := glfw.GetPrimaryMonitor()
-	if err != nil {
-		log.Fatal(err)
-	}
+	fatalErr(err)
 	mode, err := monitor.GetVideoMode()
-	if err != nil {
-		log.Fatal(err)
-	}
+	fatalErr(err)
 
 	if fullscreen {
 		width = mode.Width
 		height = mode.Height
-		glfw.WindowHint(glfw.Decorated, 0)
+		fatalErr(glfw.WindowHint(glfw.Decorated, 0))
 	} else {
 		monitor = nil
 	}
 
-	glfw.WindowHint(glfw.ContextVersionMajor, 2)
-	glfw.WindowHint(glfw.ContextVersionMinor, 1)
+	fatalErr(glfw.WindowHint(glfw.ContextVersionMajor, 2))
+	fatalErr(glfw.WindowHint(glfw.ContextVersionMinor, 1))
 
 	window, err = glfw.CreateWindow(width, height, title, nil, nil)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer window.Destroy()
+	fatalErr(err)
 	window.MakeContextCurrent()
 
-	width, height = window.GetSize()
+	width, height, err = window.GetSize()
+	fatalErr(err)
 
 	if !fullscreen {
-		window.SetPosition((mode.Width-width)/2, (mode.Height-height)/2)
+		fatalErr(window.SetPosition((mode.Width-width)/2, (mode.Height-height)/2))
 	}
 
-	glfw.SwapInterval(1)
+	fatalErr(glfw.SwapInterval(1))
 
 	gl = webgl.NewContext()
 
 	gl.Viewport(0, 0, width, height)
 	window.SetSizeCallback(func(window *glfw.Window, w, h int) {
-		width, height = window.GetSize()
+		width, height, err = window.GetSize()
+		fatalErr(err)
 		gl.Viewport(0, 0, width, height)
 		responder.Resize(width, height)
 	})
@@ -79,7 +79,8 @@ func run(title string, width, height int, fullscreen bool) {
 	})
 
 	window.SetMouseButtonCallback(func(window *glfw.Window, b glfw.MouseButton, a glfw.Action, m glfw.ModifierKey) {
-		x, y := window.GetCursorPosition()
+		x, y, err := window.GetCursorPosition()
+		fatalErr(err)
 		if a == glfw.Press {
 			responder.Mouse(float32(x), float32(y), PRESS)
 		} else {
@@ -107,29 +108,38 @@ func run(title string, width, height int, fullscreen bool) {
 	Files.Load(func() {})
 	responder.Setup()
 
-	for !window.ShouldClose() {
+	shouldClose, err := window.ShouldClose()
+	fatalErr(err)
+	for !shouldClose {
 		responder.Update(Time.Delta())
 		gl.Clear(gl.COLOR_BUFFER_BIT)
 		responder.Render()
-		window.SwapBuffers()
-		glfw.PollEvents()
+		fatalErr(window.SwapBuffers())
+		fatalErr(glfw.PollEvents())
 		Time.Tick()
+
+		shouldClose, err = window.ShouldClose()
+		fatalErr(err)
 	}
+	fatalErr(window.Destroy())
+	fatalErr(glfw.Terminate())
 	responder.Close()
 }
 
 func width() float32 {
-	width, _ := window.GetSize()
+	width, _, err := window.GetSize()
+	fatalErr(err)
 	return float32(width)
 }
 
 func height() float32 {
-	_, height := window.GetSize()
+	_, height, err := window.GetSize()
+	fatalErr(err)
 	return float32(height)
 }
 
 func exit() {
-	window.SetShouldClose(true)
+	fatalErr(window.SetShouldClose(true))
 }
 
 func init() {


### PR DESCRIPTION
I thought I'd be kind and submit a PR to upgrade engi to use the latest `azul3d.org/native/glfw.v4`.

Version four was tagged/released yesterday. Again it just follows the `go-gl/glfw3` `devel_glfw3.1` branch, but at the latest revision (as of today). The primary backwards-incompatible change was having each function possibly return an error, which solves a deadlock issue in some cases (see [PR here](https://github.com/go-gl/glfw3/pull/94)).

There will probably be a v5 release with a few minor touchups once GLFW 3.1 has actually been released as _stable_, and then everything will settle down and follow GLFW's release schedule most likely.

`glfw.v3` and `glfw.v3.1` (old/incorrect import path) will still continue to work as-is, though, so no worries.

FWIW I tested the demo's, but only on Linux.
