### PR TITLE
Fix fullscreen on OS X 

### DIFF
--- a/engi_glfw.go
+++ b/engi_glfw.go
@@ -51,7 +51,7 @@ func run(title string, width, height int, fullscreen bool) {
 	fatalErr(glfw.WindowHint(glfw.ContextVersionMajor, 2))
 	fatalErr(glfw.WindowHint(glfw.ContextVersionMinor, 1))
 
-	window, err = glfw.CreateWindow(width, height, title, nil, nil)
+	window, err = glfw.CreateWindow(width, height, title, monitor, nil)
 	fatalErr(err)
 	window.MakeContextCurrent()
 


### PR DESCRIPTION
I know the dev branch is totally different but but here's a PR:
Going fullscreen didn't hide the dock/menu bar on OS X Mavericks. This seems to help. 
I haven't been able to check other OSes.
